### PR TITLE
Add nether gold ore to grinding table

### DIFF
--- a/src/main/resources/data/simplequern/recipes/nether_gold_dust.json
+++ b/src/main/resources/data/simplequern/recipes/nether_gold_dust.json
@@ -2,7 +2,7 @@
   "type": "simplequern:grinding",
   "input": {
     "type": "item",
-    "id": "minecraft:gold_ore"
+    "id": "minecraft:nether_gold_ore"
   },
   "tier": 2,
   "time": 5,


### PR DESCRIPTION
I noticed that it wasn't possible to grind nether gold ore into gold dust, so I added it.

I also moved a couple of lines in `gold_dust.json` to make it match the rest of the files.